### PR TITLE
Replace uses of deprecated `RouterTestingModule` with `RouterModule`

### DIFF
--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -5,7 +5,7 @@ import { MatListModule } from '@angular/material/list';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
@@ -13,7 +13,7 @@ describe('AppComponent', () => {
     TestBed.configureTestingModule({
     imports: [
         BrowserAnimationsModule,
-        RouterTestingModule,
+        RouterModule.forRoot([]),
         MatToolbarModule,
         MatIconModule,
         MatSidenavModule,

--- a/client/src/app/users/add-user.component.spec.ts
+++ b/client/src/app/users/add-user.component.spec.ts
@@ -9,7 +9,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { MockUserService } from 'src/testing/user.service.mock';
 import { AddUserComponent } from './add-user.component';
@@ -34,7 +34,7 @@ describe('AddUserComponent', () => {
         MatSelectModule,
         MatInputModule,
         BrowserAnimationsModule,
-        RouterTestingModule,
+        RouterModule,
         AddUserComponent
     ],
 }).compileComponents().catch(error => {
@@ -282,7 +282,7 @@ describe('AddUserComponent#submitForm()', () => {
         MatSelectModule,
         MatInputModule,
         BrowserAnimationsModule,
-        RouterTestingModule.withRoutes([
+        RouterModule.forRoot([
             { path: 'users/1', component: UserProfileComponent }
         ]),
         AddUserComponent, UserProfileComponent],

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { MatCardModule } from '@angular/material/card';
 import { ActivatedRoute } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { RouterModule } from '@angular/router';
 import { throwError } from 'rxjs';
 import { ActivatedRouteStub } from '../../testing/activated-route-stub';
 import { MockUserService } from '../../testing/user.service.mock';
@@ -24,7 +24,7 @@ describe('UserProfileComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule,
+        RouterModule,
         MatCardModule,
         UserProfileComponent,
         UserCardComponent,


### PR DESCRIPTION
I was able to replace the use of `RouterTestingModule` following the instructions in the deprecation message: 

> @deprecated
Use provideRouter or RouterModule/RouterModule.forRoot instead. This module was previously used to provide a helpful collection of test fakes, most notably those for Location and LocationStrategy. These are generally not required anymore, as MockPlatformLocation is provided in TestBed by default. However, you can use them directly with provideLocationMocks.

combined with the useful posts here: https://github.com/angular/angular/issues/54853 and particularly the example mentioned here: https://github.com/angular/angular/issues/54853#issuecomment-1997566987

This PR relates to a previous commit where I replaced one additional instance of RouterTestingModule: 5fb17667ffe3479ea128efc7e4e531786156ad48

Both commits relate to an issue in the repo from which this fork came: https://github.com/UMM-CSci-3601/3601-iteration-template/issues/1581